### PR TITLE
Update/Fix sanity test

### DIFF
--- a/plugins/doc_fragments/ds8000.py
+++ b/plugins/doc_fragments/ds8000.py
@@ -36,7 +36,7 @@ options:
   port:
     description:
     - The port number of the DS8000 storage system HMC.
-    type: str
+    type: int
     default: 8452
 requirements:
   - pyds8k >= 1.4.0

--- a/plugins/module_utils/ds8000.py
+++ b/plugins/module_utils/ds8000.py
@@ -72,7 +72,7 @@ class Ds8000ManagerBase(object):
     def does_ds8000_object_exist(self, function, *args, **kwargs):
         try:
             return function(*args, **kwargs)
-        except pyds8k.exceptions.NotFound as generic_exc:
+        except pyds8k.exceptions.NotFound:
             return None
         except Exception as generic_exc:
             self.failed = True
@@ -102,6 +102,6 @@ def ds8000_argument_spec():
         hostname=dict(type='str', required=True),
         username=dict(type='str', required=True),
         password=dict(type='str', no_log=True, required=True),
-        port=dict(type='str', required=False, default='8452'),
+        port=dict(type='int', required=False, default=8452),
         validate_certs=dict(type='bool', required=False, default=True),
     )

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,0 +1,5 @@
+plugins/modules/ds8000_host_port.py validate-modules:missing-gplv3-license # Licence is Apache-2.0
+plugins/modules/ds8000_host.py validate-modules:missing-gplv3-license # Licence is Apache-2.0
+plugins/modules/ds8000_volume_info.py validate-modules:missing-gplv3-license # Licence is Apache-2.0
+plugins/modules/ds8000_volume_mapping.py validate-modules:missing-gplv3-license # Licence is Apache-2.0
+plugins/modules/ds8000_volume.py validate-modules:missing-gplv3-license # Licence is Apache-2.0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
sanity test failed because devel version changed to 2.14 revealing new complaints

`incompatible-default-type: DOCUMENTATION.options.port: Argument defines default as (8452) but this is incompatible with parameter type str: Value must be string for dictionary value @ data['options']['port']. Got {'description': ['The port number of the DS8000 storage system HMC.'], 'type': 'str', 'default': 8452}`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

change port to int

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/doc_fragments/ds8000.py
plugins/module_utils/ds8000.py
