### PR TITLE
Update sanity test python version

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -15,14 +15,13 @@ on:
     - cron: '0 6 * * *'
 env:
   NAMESPACE: ibm
-  COLLECTION_NAME: ds8000 
+  COLLECTION_NAME: ds8000
 
 jobs:
-
-###
-# Sanity tests (REQUIRED)
-#
-# https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html
+  ###
+  # Sanity tests (REQUIRED)
+  #
+  # https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html
 
   sanity:
     name: Sanity (Ⓐ${{ matrix.ansible }})
@@ -39,7 +38,6 @@ jobs:
           - devel
     runs-on: ubuntu-latest
     steps:
-
       # ansible-test requires the collection to be in a directory in the form
       # .../ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}/
 
@@ -53,7 +51,7 @@ jobs:
         with:
           # it is just required to run that once as "ansible-test sanity" in the docker image
           # will run on all python versions it supports.
-          python-version: 3.8
+          python-version: 3.9
 
       # Install the head of the given branch (devel, stable-2.10)
       - name: Install ansible-base (${{ matrix.ansible }})


### PR DESCRIPTION
##### SUMMARY
ansible-core devel no longer supports Python 3.8 for the controller.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
github actions

##### ADDITIONAL INFORMATION

