### PR TITLE
Replace ansible.module_utils.six with Python stdlib equivalents

### DIFF
--- a/changelogs/fragments/remove-module-utils-six.yml
+++ b/changelogs/fragments/remove-module-utils-six.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Replace the deprecated ``ansible.module_utils.six`` compatibility shims with
+    their Python standard library equivalents. ``ansible.module_utils.six`` is
+    deprecated in ansible-core 2.21 and is scheduled for removal in 2.24.

--- a/plugins/module_utils/ds8000.py
+++ b/plugins/module_utils/ds8000.py
@@ -11,7 +11,6 @@ import abc
 import json
 import traceback
 
-from ansible.module_utils import six
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
 
@@ -34,8 +33,7 @@ PRESENT = 'present'
 ABSENT = 'absent'
 
 
-@six.add_metaclass(abc.ABCMeta)
-class Ds8000ManagerBase(object):
+class Ds8000ManagerBase(object, metaclass=abc.ABCMeta):
     def __init__(self, module):
 
         if not HAS_PYDS8K:


### PR DESCRIPTION
##### SUMMARY

`ansible.module_utils.six` is deprecated in ansible-core 2.21 and scheduled for removal in 2.24. The only use is the metaclass decorator:

```python
-from ansible.module_utils import six
-@six.add_metaclass(abc.ABCMeta)
-class Ds8000ManagerBase(object):
+class Ds8000ManagerBase(object, metaclass=abc.ABCMeta):
```

The keyword form produces the same result as the decorator: same `type` (`abc.ABCMeta`), same `__bases__` (`(object,)`), same MRO and same `__abstractmethods__`. All subclasses across `plugins/modules/` are unaffected. This file already carries `compile-2.6/2.7/3.5!skip` entries in the older sanity ignore files, and `tests/config.yml` declares `python_requires: '>=3.6'`, so the Python 3 keyword syntax cannot break a sanity job. A changelog fragment is included.

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

plugins/module_utils/ds8000.py
